### PR TITLE
Feature/6 torch losses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         "tensorflow_probability==0.22",  # fixed for compatibility with tensorflow < 2.16
         "pyarrow",
         "seaborn",
+        "typing-extensions>=4.8.0",
     ],
     extras_require={
         "dev": [

--- a/src/dlomix/losses/__init__.py
+++ b/src/dlomix/losses/__init__.py
@@ -1,3 +1,4 @@
 from .intensity import masked_pearson_correlation_distance, masked_spectral_distance
+from .intensity_torch import masked_spectral_distance_torch
 
-__all__ = ["masked_spectral_distance", "masked_pearson_correlation_distance"]
+__all__ = ["masked_spectral_distance", "masked_pearson_correlation_distance", "masked_spectral_distance_torch"]

--- a/src/dlomix/losses/__init__.py
+++ b/src/dlomix/losses/__init__.py
@@ -1,4 +1,4 @@
 from .intensity import masked_pearson_correlation_distance, masked_spectral_distance
-from .intensity_torch import masked_spectral_distance_torch
+from .intensity_torch import masked_spectral_distance_torch, masked_pearson_correlation_distance_torch
 
-__all__ = ["masked_spectral_distance", "masked_pearson_correlation_distance", "masked_spectral_distance_torch"]
+__all__ = ["masked_spectral_distance", "masked_pearson_correlation_distance", "masked_spectral_distance_torch", "masked_pearson_correlation_distance_torch"]

--- a/src/dlomix/losses/intensity.py
+++ b/src/dlomix/losses/intensity.py
@@ -76,7 +76,7 @@ def masked_pearson_correlation_distance(y_true, y_pred):
     pred_masked = ((y_true + 1) * y_pred) / (y_true + 1 + epsilon)
     true_masked = ((y_true + 1) * y_true) / (y_true + 1 + epsilon)
 
-    mx = tf.math.reduce_mean(true_masked)
+    mx = tf.math.reduce_mean(true_masked) # If axis is None all dimensions are reduced, and a tensor with a single element is returned
     my = tf.math.reduce_mean(pred_masked)
     xm, ym = true_masked - mx, pred_masked - my
     r_num = tf.math.reduce_mean(tf.multiply(xm, ym))

--- a/src/dlomix/losses/intensity_torch.py
+++ b/src/dlomix/losses/intensity_torch.py
@@ -82,6 +82,6 @@ def masked_pearson_correlation_distance_torch(y_true: torch.Tensor, y_pred: torc
     my = pred_masked.mean()
     xm, ym = true_masked - mx, pred_masked - my
     r_num = (xm * ym).mean()
-    r_den = xm.std() * ym.std()  # TODO check if I need to set unbiased=False
+    r_den = xm.std(unbiased=False) * ym.std(unbiased=False)
 
     return 1 - (r_num / r_den)

--- a/src/dlomix/losses/intensity_torch.py
+++ b/src/dlomix/losses/intensity_torch.py
@@ -49,3 +49,39 @@ def masked_spectral_distance_torch(y_true: torch.Tensor, y_pred: torch.Tensor) -
     arccos = torch.arccos(product)
 
     return 2 * arccos / np.pi
+
+
+def masked_pearson_correlation_distance_torch(y_true, y_pred):
+    """
+    Calculates the masked Pearson correlation distance between true and predicted intensity vectors.
+    The masked Pearson correlation distance is a metric for comparing the similarity between two intensity vectors,
+    taking into account only the non-negative values in the true values tensor (which represent valid peaks).
+
+    Parameters
+    ----------
+    y_true : tf.Tensor
+        A tensor containing the true values, with shape `(batch_size, num_values)`.
+    y_pred : tf.Tensor
+        A tensor containing the predicted values, with the same shape as `y_true`.
+
+    Returns
+    -------
+    tf.Tensor
+        A tensor containing the masked Pearson correlation distance between `y_true` and `y_pred`.
+
+    """
+
+    epsilon = 1e-7
+
+    # Masking: we multiply values by (true + 1) because then the peaks that cannot
+    # be there (and have value of -1 as explained above) won't be considered
+    pred_masked = ((y_true + 1) * y_pred) / (y_true + 1 + epsilon)
+    true_masked = ((y_true + 1) * y_true) / (y_true + 1 + epsilon)
+
+    mx = true_masked.mean()
+    my = pred_masked.mean()
+    xm, ym = true_masked - mx, pred_masked - my
+    r_num = (xm * ym).mean()
+    r_den = xm.std() * ym.std()  # TODO check if I need to set unbiased=False
+
+    return 1 - (r_num / r_den)

--- a/src/dlomix/losses/intensity_torch.py
+++ b/src/dlomix/losses/intensity_torch.py
@@ -51,7 +51,7 @@ def masked_spectral_distance_torch(y_true: torch.Tensor, y_pred: torch.Tensor) -
     return 2 * arccos / np.pi
 
 
-def masked_pearson_correlation_distance_torch(y_true, y_pred):
+def masked_pearson_correlation_distance_torch(y_true: torch.Tensor, y_pred: torch.Tensor) -> torch.Tensor:
     """
     Calculates the masked Pearson correlation distance between true and predicted intensity vectors.
     The masked Pearson correlation distance is a metric for comparing the similarity between two intensity vectors,
@@ -59,14 +59,14 @@ def masked_pearson_correlation_distance_torch(y_true, y_pred):
 
     Parameters
     ----------
-    y_true : tf.Tensor
+    y_true : torch.Tensor
         A tensor containing the true values, with shape `(batch_size, num_values)`.
-    y_pred : tf.Tensor
+    y_pred : torch.Tensor
         A tensor containing the predicted values, with the same shape as `y_true`.
 
     Returns
     -------
-    tf.Tensor
+    torch.Tensor
         A tensor containing the masked Pearson correlation distance between `y_true` and `y_pred`.
 
     """

--- a/src/dlomix/losses/intensity_torch.py
+++ b/src/dlomix/losses/intensity_torch.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 
 
-def masked_spectral_distance_torch(y_true: torch.tensor, y_pred: torch.tensor) -> torch.tensor:
+def masked_spectral_distance_torch(y_true: torch.Tensor, y_pred: torch.Tensor) -> torch.Tensor:
     """
     Calculates the masked spectral distance between true and predicted intensity vectors.
     The masked spectral distance is a metric for comparing the similarity between two intensity vectors.
@@ -16,14 +16,14 @@ def masked_spectral_distance_torch(y_true: torch.tensor, y_pred: torch.tensor) -
 
     Parameters
     ----------
-    y_true : tf.Tensor
+    y_true : torch.Tensor
         A tensor containing the true values, with shape `(batch_size, num_values)`.
-    y_pred : tf.Tensor
+    y_pred : torch.Tensor
         A tensor containing the predicted values, with the same shape as `y_true`.
 
     Returns
     -------
-    tf.Tensor
+    torch.Tensor
         A tensor containing the masked spectral distance between `y_true` and `y_pred`.
 
     """

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -3,13 +3,12 @@ import logging
 import numpy as np
 import tensorflow as tf
 
-from dlomix.losses import masked_spectral_distance
+from dlomix.losses import masked_spectral_distance, masked_pearson_correlation_distance
 
 logger = logging.getLogger(__name__)
 
 
 # ------------------ intensity - masked spectral distance ------------------
-
 
 def test_spectral_distance_identical():
     y_true = [[0.1, 0.2, 0.3]]
@@ -41,5 +40,36 @@ def test_spectral_distance_zero_input():
     sa = masked_spectral_distance(y_true_tensor, y_pred_tensor)
     logger.info("Spectral Angle for zero input vectors: {}".format(sa.numpy()))
 
+# ------------------ intensity - masked pearson correlation distance ------------------
+
+def test_pearson_correlation_distance_identical():
+    y_true = [[0.1, 0.2, 0.3]]
+    y_true_tensor = tf.convert_to_tensor(y_true)
+    y_pred_tensor = tf.convert_to_tensor(y_true)
+
+    pc = masked_pearson_correlation_distance(y_true_tensor, y_pred_tensor)
+    logger.info("Masked Pearson Correlation Distance for identical vectors: {}".format(pc.numpy()))
+
+    assert pc.numpy() == 0
+
+
+def test_pearson_correlation_distance_different():
+    y_true = [[0.1, 0.2, 0.3]]
+    y_true_tensor = tf.convert_to_tensor(y_true)
+    y_pred_tensor = tf.convert_to_tensor([list(reversed(y_true[0]))])
+
+    pc = masked_pearson_correlation_distance(y_true_tensor, y_pred_tensor)
+    logger.info("Masked Pearson Correlation Distance for reversed vectors: {}".format(pc.numpy()))
+
+    assert pc.numpy() != 0
+
+
+def test_pearson_correlation_distance_zero_input():
+    y_true = [[0.0, 0.0, 0.0]]
+    y_true_tensor = tf.convert_to_tensor(y_true)
+    y_pred_tensor = tf.convert_to_tensor(y_true)
+
+    pc = masked_pearson_correlation_distance(y_true_tensor, y_pred_tensor)
+    logger.info("Masked Pearson Correlation Distance for zero input vectors: {}".format(pc.numpy()))
 
 # ---------------------------------------------------------------------------

--- a/tests/test_torch_losses.py
+++ b/tests/test_torch_losses.py
@@ -28,7 +28,7 @@ def test_tf_torch_equivalence_masked_spectral_distance():
 
     logger.info(f"Spectral Angle: for tf: {sa_tf.numpy()} vs for torch: {sa_torch.numpy()}")
 
-    assert (sa_tf.numpy() == sa_torch.numpy()).all() # alternatively try np.array_equiv(A,B)
+    assert np.allclose(sa_tf.numpy(), sa_torch.numpy()) # alternatively try np.array_equiv(A,B)
 
 
 # ------------------ intensity - masked pearson correlation distance ------------------
@@ -49,4 +49,4 @@ def test_tf_torch_equivalence_masked_pearson_correlation_distance():
 
     logger.info(f"Masked Pearson Correlation Distance: for tf: {pc_tf.numpy()} vs for torch: {pc_torch.numpy()}")
 
-    assert (pc_tf.numpy() == pc_torch.numpy()).all() # alternatively try np.array_equiv(A,B)
+    assert np.allclose(pc_tf.numpy(), pc_torch.numpy()) # alternatively try np.array_equiv(A,B)

--- a/tests/test_torch_losses.py
+++ b/tests/test_torch_losses.py
@@ -4,17 +4,16 @@ import numpy as np
 import tensorflow as tf
 import torch
 
-from dlomix.losses import masked_spectral_distance
-from dlomix.losses import masked_spectral_distance_torch
+from dlomix.losses import masked_spectral_distance, masked_pearson_correlation_distance
+from dlomix.losses import masked_spectral_distance_torch, masked_pearson_correlation_distance_torch
 
 logger = logging.getLogger(__name__)
 
 
 # ------------------ intensity - masked spectral distance ------------------
 
-
 def test_tf_torch_equivalence_masked_spectral_distance():
-    
+
     y_true = [[0.1, 0.2, 0.3]]
     y_pred = [list(reversed(y_true[0]))]
 
@@ -30,3 +29,24 @@ def test_tf_torch_equivalence_masked_spectral_distance():
     logger.info(f"Spectral Angle: for tf: {sa_tf.numpy()} vs for torch: {sa_torch.numpy()}")
 
     assert (sa_tf.numpy() == sa_torch.numpy()).all() # alternatively try np.array_equiv(A,B)
+
+
+# ------------------ intensity - masked pearson correlation distance ------------------
+
+def test_tf_torch_equivalence_masked_pearson_correlation_distance():
+
+    y_true = [[0.1, 0.2, 0.3]]
+    y_pred = [list(reversed(y_true[0]))]
+
+    pc_tf = masked_pearson_correlation_distance(
+        tf.convert_to_tensor(y_true), 
+        tf.convert_to_tensor(y_pred)
+    )
+    pc_torch = masked_pearson_correlation_distance_torch(
+        torch.tensor(y_true), 
+        torch.tensor(y_pred)
+    )
+
+    logger.info(f"Masked Pearson Correlation Distance: for tf: {pc_tf.numpy()} vs for torch: {pc_torch.numpy()}")
+
+    assert (pc_tf.numpy() == pc_torch.numpy()).all() # alternatively try np.array_equiv(A,B)

--- a/tests/test_torch_losses.py
+++ b/tests/test_torch_losses.py
@@ -1,0 +1,32 @@
+import logging
+
+import numpy as np
+import tensorflow as tf
+import torch
+
+from dlomix.losses import masked_spectral_distance
+from dlomix.losses import masked_spectral_distance_torch
+
+logger = logging.getLogger(__name__)
+
+
+# ------------------ intensity - masked spectral distance ------------------
+
+
+def test_tf_torch_equivalence_masked_spectral_distance():
+    
+    y_true = [[0.1, 0.2, 0.3]]
+    y_pred = [list(reversed(y_true[0]))]
+
+    sa_tf = masked_spectral_distance(
+        tf.convert_to_tensor(y_true), 
+        tf.convert_to_tensor(y_pred)
+    )
+    sa_torch = masked_spectral_distance_torch(
+        torch.tensor(y_true), 
+        torch.tensor(y_pred)
+    )
+
+    logger.info(f"Spectral Angle: for tf: {sa_tf.numpy()} vs for torch: {sa_torch.numpy()}")
+
+    assert (sa_tf.numpy() == sa_torch.numpy()).all() # alternatively try np.array_equiv(A,B)


### PR DESCRIPTION
* torch implementations for the two currently existing custom tf loss functions in dlomix
* tests for equivalence of output of tf & torch loss functions
* in addition, 3 tests for the existing masked_pearson_correlation_distance loss added to test_losses (equivalent to the ones for Masked Spectral Distance)

closes #6 