### PR TITLE
Initial extension of torch dataset and tests

### DIFF
--- a/run_scripts/run_prosit_retentiontime_torch.py
+++ b/run_scripts/run_prosit_retentiontime_torch.py
@@ -7,7 +7,6 @@ import tensorflow as tf
 from dlomix.data import RetentionTimeDataset
 from dlomix.eval import TimeDeltaMetric
 from dlomix.models import PrositRetentionTimePredictor
-from dlomix.reports import RetentionTimeReport
 
 TRAIN_DATAPATH = "example_dataset/proteomTools_train_val.csv"
 TEST_DATAPATH = "example_dataset/proteomTools_test.csv"
@@ -36,51 +35,4 @@ for x in d.tensor_train_data:
     break
 
 
-# TODO: Continue with models
-
-print(1 / 0)
-
-model = PrositRetentionTimePredictor(seq_length=30)
-optimizer = tf.keras.optimizers.Adam(lr=0.0001)
-
-model.compile(
-    optimizer=optimizer, loss="mse", metrics=["mean_absolute_error", TimeDeltaMetric()]
-)
-
-weights_file = "./prosit_test"
-checkpoint = tf.keras.callbacks.ModelCheckpoint(
-    weights_file, save_best_only=True, save_weights_only=True
-)
-decay = tf.keras.callbacks.ReduceLROnPlateau(
-    monitor="val_loss", factor=0.1, patience=10, verbose=1, min_lr=0
-)
-early_stop = tf.keras.callbacks.EarlyStopping(patience=20)
-callbacks = [checkpoint, early_stop, decay]
-
-
-history = model.fit(
-    d.tensor_train_data,
-    epochs=25,
-    validation_data=d.tensor_val_data,
-    callbacks=callbacks,
-)
-
-predictions = model.predict(test_sequences)
-predictions = predictions.ravel()
-
-print(test_sequences[:5])
-print(test_targets[:5])
-print(predictions[:5])
-
-
-report = RetentionTimeReport(output_path="run_scripts/output", history=history)
-
-print("R2: ", report.calculate_r2(test_targets, predictions))
-
-pd.DataFrame(
-    {
-        "sequence": d["test"]["_parsed_sequence"],
-        "irt": test_targets,
-        "predicted_irt": predictions,
-    }
-).to_csv("run_scripts/output/predictions_prosit_fullrun.csv", index=False)
+# TODO: Continue with models and training

--- a/run_scripts/run_prosit_retentiontime_torch.py
+++ b/run_scripts/run_prosit_retentiontime_torch.py
@@ -1,0 +1,86 @@
+import os
+import sys
+
+import pandas as pd
+import tensorflow as tf
+
+from dlomix.data import RetentionTimeDataset
+from dlomix.eval import TimeDeltaMetric
+from dlomix.models import PrositRetentionTimePredictor
+from dlomix.reports import RetentionTimeReport
+
+TRAIN_DATAPATH = "example_dataset/proteomTools_train_val.csv"
+TEST_DATAPATH = "example_dataset/proteomTools_test.csv"
+
+d = RetentionTimeDataset(
+    data_format="csv",
+    data_source=TRAIN_DATAPATH,
+    test_data_source=TEST_DATAPATH,
+    sequence_column="sequence",
+    label_column="irt",
+    max_seq_len=30,
+    batch_size=512,
+    val_ratio=0.2,
+    dataset_type="pt",
+)
+
+print(d)
+print(d["train"]["sequence"][0:2])
+print(d["train"]["irt"][0:2])
+
+test_targets = d["test"]["irt"]
+test_sequences = d["test"]["sequence"]
+
+for x in d.tensor_train_data:
+    print(x)
+    break
+
+
+# TODO: Continue with models
+
+print(1 / 0)
+
+model = PrositRetentionTimePredictor(seq_length=30)
+optimizer = tf.keras.optimizers.Adam(lr=0.0001)
+
+model.compile(
+    optimizer=optimizer, loss="mse", metrics=["mean_absolute_error", TimeDeltaMetric()]
+)
+
+weights_file = "./prosit_test"
+checkpoint = tf.keras.callbacks.ModelCheckpoint(
+    weights_file, save_best_only=True, save_weights_only=True
+)
+decay = tf.keras.callbacks.ReduceLROnPlateau(
+    monitor="val_loss", factor=0.1, patience=10, verbose=1, min_lr=0
+)
+early_stop = tf.keras.callbacks.EarlyStopping(patience=20)
+callbacks = [checkpoint, early_stop, decay]
+
+
+history = model.fit(
+    d.tensor_train_data,
+    epochs=25,
+    validation_data=d.tensor_val_data,
+    callbacks=callbacks,
+)
+
+predictions = model.predict(test_sequences)
+predictions = predictions.ravel()
+
+print(test_sequences[:5])
+print(test_targets[:5])
+print(predictions[:5])
+
+
+report = RetentionTimeReport(output_path="run_scripts/output", history=history)
+
+print("R2: ", report.calculate_r2(test_targets, predictions))
+
+pd.DataFrame(
+    {
+        "sequence": d["test"]["_parsed_sequence"],
+        "irt": test_targets,
+        "predicted_irt": predictions,
+    }
+).to_csv("run_scripts/output/predictions_prosit_fullrun.csv", index=False)

--- a/src/dlomix/data/charge_state.py
+++ b/src/dlomix/data/charge_state.py
@@ -19,7 +19,7 @@ class ChargeStateDataset(PeptideDataset):
         label_column (str): The name of the column containing the charge state labels. Default is "most_abundant_charge_by_count".
         val_ratio (float): The ratio of validation data to split from the training data. Default is 0.2.
         max_seq_len (Union[int, str]): The maximum length of the peptide sequences. Default is 30.
-        dataset_type (str): The type of dataset to use. Default is "tf".
+        dataset_type (str): The type of dataset to use. Default is "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for training and evaluation. Default is 256.
         model_features (Optional[List[str]]): The list of features to use for the model. Default is None.
         dataset_columns_to_keep (Optional[List[str]]): The list of columns to keep in the dataset. Default is None.

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -637,40 +637,59 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
 
     @property
     def tensor_train_data(self):
-        """TensorFlow Dataset object for the training data"""
-        tf_dataset = self._get_split_tf_dataset(PeptideDataset.DEFAULT_SPLIT_NAMES[0])
+        """TensorFlow or Torch Dataset object for the training data"""
+        if self.dataset_type == "pt":
+            return self._get_split_torch_dataset(PeptideDataset.DEFAULT_SPLIT_NAMES[0])
+        else:
+            tf_dataset = self._get_split_tf_dataset(
+                PeptideDataset.DEFAULT_SPLIT_NAMES[0]
+            )
 
-        if self.enable_tf_dataset_cache:
-            tf_dataset = tf_dataset.cache()
+            if self.enable_tf_dataset_cache:
+                tf_dataset = tf_dataset.cache()
 
-        return tf_dataset
+            return tf_dataset
 
     @property
     def tensor_val_data(self):
-        """TensorFlow Dataset object for the val data"""
-        tf_dataset = self._get_split_tf_dataset(PeptideDataset.DEFAULT_SPLIT_NAMES[1])
+        """TensorFlow or Torch Dataset object for the val data"""
+        if self.dataset_type == "pt":
+            return self._get_split_torch_dataset(PeptideDataset.DEFAULT_SPLIT_NAMES[1])
+        else:
+            tf_dataset = self._get_split_tf_dataset(
+                PeptideDataset.DEFAULT_SPLIT_NAMES[1]
+            )
 
-        if self.enable_tf_dataset_cache:
-            tf_dataset = tf_dataset.cache()
+            if self.enable_tf_dataset_cache:
+                tf_dataset = tf_dataset.cache()
 
-        return tf_dataset
+            return tf_dataset
 
     @property
     def tensor_test_data(self):
-        """TensorFlow Dataset object for the test data"""
-        tf_dataset = self._get_split_tf_dataset(PeptideDataset.DEFAULT_SPLIT_NAMES[2])
+        """TensorFlow or Torch Dataset object for the test data"""
+        if self.dataset_type == "pt":
+            return self._get_split_torch_dataset(PeptideDataset.DEFAULT_SPLIT_NAMES[2])
+        else:
+            tf_dataset = self._get_split_tf_dataset(
+                PeptideDataset.DEFAULT_SPLIT_NAMES[2]
+            )
 
-        if self.enable_tf_dataset_cache:
-            tf_dataset = tf_dataset.cache()
+            if self.enable_tf_dataset_cache:
+                tf_dataset = tf_dataset.cache()
 
-        return tf_dataset
+            return tf_dataset
 
-    def _get_split_tf_dataset(self, split_name: str):
+    def _check_if_split_exists(self, split_name: str):
         existing_splits = list(self.hf_dataset.keys())
         if split_name not in existing_splits:
             raise ValueError(
                 f"Split '{split_name}' does not exist in the dataset. Available splits are: {existing_splits}"
             )
+        return True
+
+    def _get_split_tf_dataset(self, split_name: str):
+        self._check_if_split_exists(split_name)
 
         return self.hf_dataset[split_name].to_tf_dataset(
             columns=self._get_input_tensor_column_names(),
@@ -678,6 +697,25 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
             shuffle=False,
             batch_size=self.batch_size,
         )
+
+    def _get_split_torch_dataset(self, split_name: str):
+        self._check_if_split_exists(split_name)
+
+        from torch.utils.data import DataLoader
+
+        data_loader = DataLoader(
+            dataset=self.hf_dataset[split_name].with_format(
+                type="torch",
+                columns=[*self._get_input_tensor_column_names(), self.label_column],
+            ),
+            batch_size=self.batch_size,
+            shuffle=False,
+        )
+
+        return data_loader
+
+
+# ------------------------------------------------------------------------------------------------
 
 
 def load_processed_dataset(path: str):

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -54,7 +54,7 @@ class PeptideDataset:
     max_seq_len : int
         Maximum sequence length to pad the sequences to. If set to 0, the sequences will not be padded.
     dataset_type : str
-        Type of the tensor dataset to be generated afterwards. Possible values are "tf" and "pt" for TensorFlow and PyTorch respectively.
+        Type of the tensor dataset to be generated afterwards. Possible values are "tf" and "pt" for TensorFlow and PyTorch, respectively. Fallback is to TensorFlow dataset tensors.
     batch_size : int
         Batch size for the tensor dataset.
     model_features : List[str]

--- a/src/dlomix/data/detectability.py
+++ b/src/dlomix/data/detectability.py
@@ -19,7 +19,7 @@ class DetectabilityDataset(PeptideDataset):
         label_column (str): The name of the column containing the class labels. Default is "Classes".
         val_ratio (float): The ratio of validation data to split from the training data. Default is 0.2.
         max_seq_len (Union[int, str]): The maximum length of the peptide sequences. Default is 30.
-        dataset_type (str): The type of dataset to use. Default is "tf".
+        dataset_type (str): The type of dataset to use. Default is "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for training and evaluation. Default is 256.
         model_features (Optional[List[str]]): The list of features to use for the model. Default is None.
         dataset_columns_to_keep (Optional[List[str]]): The list of columns to keep in the dataset. Default is ["Proteins"].

--- a/src/dlomix/data/fragment_ion_intensity.py
+++ b/src/dlomix/data/fragment_ion_intensity.py
@@ -19,7 +19,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         label_column (str): The name of the column containing the intensity labels.
         val_ratio (float): The ratio of validation data to split from the training data.
         max_seq_len (Union[int, str]): The maximum length of the peptide sequences.
-        dataset_type (str): The type of dataset to use (e.g., "tf" for TensorFlow dataset).
+        dataset_type (str): The type of dataset to use (e.g., "tf" for TensorFlow dataset). Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for training and evaluation.
         model_features (Optional[List[str]]): The list of features to use for the model.
         dataset_columns_to_keep (Optional[List[str]]): The list of columns to keep in the dataset.

--- a/src/dlomix/data/retention_time.py
+++ b/src/dlomix/data/retention_time.py
@@ -19,7 +19,7 @@ class RetentionTimeDataset(PeptideDataset):
         label_column (str): The column name for the retention time label in the dataset. Defaults to "indexed_retention_time".
         val_ratio (float): The ratio of validation data to split from the main dataset. Defaults to 0.2.
         max_seq_len (Union[int, str]): The maximum sequence length allowed in the dataset. Defaults to 30.
-        dataset_type (str): The type of dataset to use. Defaults to "tf".
+        dataset_type (str): The type of dataset to use. Defaults to "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for the dataset. Defaults to 256.
         model_features (Optional[List[str]]): The features to use in the model. Defaults to None.
         dataset_columns_to_keep (Optional[List[str]]): The columns to keep in the dataset. Defaults to None.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+import logging
+import urllib.request
+import zipfile
+from os import makedirs
+from os.path import exists, join
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+RT_PARQUET_EXAMPLE_URL = "https://zenodo.org/record/6602020/files/TUM_missing_first_meta_data.parquet?download=1"
+RT_CSV_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/proteomTools_train_val.csv"
+INTENSITY_PARQUET_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.parquet"
+INTENSITY_CSV_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.csv"
+RT_HUB_DATASET_NAME = "Wilhelmlab/prospect-ptms-irt"
+
+RAW_GENERIC_NESTED_DATA = {
+    "seq": ["[UNIMOD:737]-DASAQTTSHELTIPN-[]", "[UNIMOD:737]-DLHTGRLC[UNIMOD:4]-[]"],
+    "nested_feature": [[[30, 64]], [[25, 35]]],
+    "label": [0.1, 0.2],
+}
+
+TEST_ASSETS_TO_DOWNLOAD = [
+    RT_PARQUET_EXAMPLE_URL,
+    RT_CSV_EXAMPLE_URL,
+    INTENSITY_PARQUET_EXAMPLE_URL,
+    INTENSITY_CSV_EXAMPLE_URL,
+]
+DOWNLOAD_PATH_FOR_ASSETS = join("tests", "assets")
+
+
+def unzip_file(zip_file_path, dest_dir):
+    with zipfile.ZipFile(zip_file_path, "r") as f:
+        f.extractall(dest_dir)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def download_assets():
+    makedirs(DOWNLOAD_PATH_FOR_ASSETS, exist_ok=True)
+    for i, http_address in enumerate(TEST_ASSETS_TO_DOWNLOAD, start=1):
+        filename = f"file_{i}"
+        filepath = join(DOWNLOAD_PATH_FOR_ASSETS, filename)
+        if ".parquet" in http_address:
+            filepath += ".parquet"
+        if ".csv" in http_address:
+            filepath += ".csv"
+        if ".zip" in http_address:
+            filepath += ".zip"
+        if exists(filepath):
+            logger.info(
+                "Skipping {} since it exists at {}".format(http_address, filepath)
+            )
+            continue
+        logger.info("Downloading: {}, to: {}".format(http_address, filepath))
+        urllib.request.urlretrieve(http_address, filepath)
+        if ".zip" in filepath:
+            logger.info(
+                "Unzipping: {}, to: {}".format(filepath, DOWNLOAD_PATH_FOR_ASSETS)
+            )
+            unzip_file(filepath, DOWNLOAD_PATH_FOR_ASSETS)
+    return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ INTENSITY_PARQUET_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/d
 INTENSITY_CSV_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.csv"
 RT_HUB_DATASET_NAME = "Wilhelmlab/prospect-ptms-irt"
 
+
 RAW_GENERIC_NESTED_DATA = {
     "seq": ["[UNIMOD:737]-DASAQTTSHELTIPN-[]", "[UNIMOD:737]-DLHTGRLC[UNIMOD:4]-[]"],
     "nested_feature": [[[30, 64]], [[25, 35]]],
@@ -26,12 +27,21 @@ TEST_ASSETS_TO_DOWNLOAD = [
     INTENSITY_PARQUET_EXAMPLE_URL,
     INTENSITY_CSV_EXAMPLE_URL,
 ]
+
 DOWNLOAD_PATH_FOR_ASSETS = join("tests", "assets")
 
 
 def unzip_file(zip_file_path, dest_dir):
     with zipfile.ZipFile(zip_file_path, "r") as f:
         f.extractall(dest_dir)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def global_variables():
+    pytest.global_variables = {
+        "RAW_GENERIC_NESTED_DATA": RAW_GENERIC_NESTED_DATA,
+        "DOWNLOAD_PATH_FOR_ASSETS": DOWNLOAD_PATH_FOR_ASSETS,
+    }
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,6 +2,7 @@ import logging
 from os.path import join
 from shutil import rmtree
 
+import pytest
 from datasets import Dataset, DatasetDict, load_dataset
 
 from dlomix.data import (
@@ -14,15 +15,6 @@ logger = logging.getLogger(__name__)
 
 RT_HUB_DATASET_NAME = "Wilhelmlab/prospect-ptms-irt"
 
-RAW_GENERIC_NESTED_DATA = {
-    "seq": ["[UNIMOD:737]-DASAQTTSHELTIPN-[]", "[UNIMOD:737]-DLHTGRLC[UNIMOD:4]-[]"],
-    "nested_feature": [[[30, 64]], [[25, 35]]],
-    "label": [0.1, 0.2],
-}
-
-
-DOWNLOAD_PATH_FOR_ASSETS = join("tests", "assets")
-
 
 def test_empty_rtdataset():
     rtdataset = RetentionTimeDataset()
@@ -32,7 +24,9 @@ def test_empty_rtdataset():
 
 def test_parquet_rtdataset():
     rtdataset = RetentionTimeDataset(
-        data_source=join(DOWNLOAD_PATH_FOR_ASSETS, "file_1.parquet"),
+        data_source=join(
+            pytest.global_variables["DOWNLOAD_PATH_FOR_ASSETS"], "file_1.parquet"
+        ),
         sequence_column="modified_sequence",
         label_column="indexed_retention_time",
     )
@@ -53,7 +47,10 @@ def test_parquet_rtdataset():
 
 def test_rtdataset_inmemory():
     hf_dataset = load_dataset(
-        "parquet", data_files=join(DOWNLOAD_PATH_FOR_ASSETS, "file_1.parquet")
+        "parquet",
+        data_files=join(
+            pytest.global_variables["DOWNLOAD_PATH_FOR_ASSETS"], "file_1.parquet"
+        ),
     )
 
     rtdataset = RetentionTimeDataset(
@@ -96,7 +93,9 @@ def test_rtdataset_hub():
 
 def test_csv_rtdataset():
     rtdataset = RetentionTimeDataset(
-        data_source=join(DOWNLOAD_PATH_FOR_ASSETS, "file_2.csv"),
+        data_source=join(
+            pytest.global_variables["DOWNLOAD_PATH_FOR_ASSETS"], "file_2.csv"
+        ),
         data_format="csv",
         sequence_column="sequence",
         label_column="irt",
@@ -125,7 +124,9 @@ def test_empty_intensitydataset():
 
 
 def test_parquet_intensitydataset():
-    filepath = join(DOWNLOAD_PATH_FOR_ASSETS, "file_3.parquet")
+    filepath = join(
+        pytest.global_variables["DOWNLOAD_PATH_FOR_ASSETS"], "file_3.parquet"
+    )
     intensity_dataset = FragmentIonIntensityDataset(
         data_format="parquet",
         data_source=filepath,
@@ -156,7 +157,7 @@ def test_parquet_intensitydataset():
 
 
 def test_csv_intensitydataset():
-    filepath = join(DOWNLOAD_PATH_FOR_ASSETS, "file_4.csv")
+    filepath = join(pytest.global_variables["DOWNLOAD_PATH_FOR_ASSETS"], "file_4.csv")
     intensity_dataset = FragmentIonIntensityDataset(
         data_format="csv",
         data_source=filepath,
@@ -186,7 +187,7 @@ def test_csv_intensitydataset():
 
 
 def test_nested_model_features():
-    hfdata = Dataset.from_dict(RAW_GENERIC_NESTED_DATA)
+    hfdata = Dataset.from_dict(pytest.global_variables["RAW_GENERIC_NESTED_DATA"])
 
     intensity_dataset = FragmentIonIntensityDataset(
         data_format="hf",
@@ -204,7 +205,7 @@ def test_nested_model_features():
 
 
 def test_save_dataset():
-    hfdata = Dataset.from_dict(RAW_GENERIC_NESTED_DATA)
+    hfdata = Dataset.from_dict(pytest.global_variables["RAW_GENERIC_NESTED_DATA"])
 
     intensity_dataset = FragmentIonIntensityDataset(
         data_format="hf",
@@ -221,7 +222,9 @@ def test_save_dataset():
 
 def test_load_dataset():
     rtdataset = RetentionTimeDataset(
-        data_source=join(DOWNLOAD_PATH_FOR_ASSETS, "file_2.csv"),
+        data_source=join(
+            pytest.global_variables["DOWNLOAD_PATH_FOR_ASSETS"], "file_2.csv"
+        ),
         data_format="csv",
         sequence_column="sequence",
         label_column="irt",
@@ -239,7 +242,7 @@ def test_load_dataset():
 
 
 def test_no_split_datasetDict_hf_inmemory():
-    hfdata = Dataset.from_dict(RAW_GENERIC_NESTED_DATA)
+    hfdata = Dataset.from_dict(pytest.global_variables["RAW_GENERIC_NESTED_DATA"])
     hf_dataset = DatasetDict({"train": hfdata})
 
     intensity_dataset = FragmentIonIntensityDataset(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,11 +1,7 @@
 import logging
-import urllib.request
-import zipfile
-from os import makedirs
-from os.path import exists, join
+from os.path import join
 from shutil import rmtree
 
-import pytest
 from datasets import Dataset, DatasetDict, load_dataset
 
 from dlomix.data import (
@@ -16,10 +12,6 @@ from dlomix.data import (
 
 logger = logging.getLogger(__name__)
 
-RT_PARQUET_EXAMPLE_URL = "https://zenodo.org/record/6602020/files/TUM_missing_first_meta_data.parquet?download=1"
-RT_CSV_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/proteomTools_train_val.csv"
-INTENSITY_PARQUET_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.parquet"
-INTENSITY_CSV_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.csv"
 RT_HUB_DATASET_NAME = "Wilhelmlab/prospect-ptms-irt"
 
 RAW_GENERIC_NESTED_DATA = {
@@ -28,45 +20,8 @@ RAW_GENERIC_NESTED_DATA = {
     "label": [0.1, 0.2],
 }
 
-TEST_ASSETS_TO_DOWNLOAD = [
-    RT_PARQUET_EXAMPLE_URL,
-    RT_CSV_EXAMPLE_URL,
-    INTENSITY_PARQUET_EXAMPLE_URL,
-    INTENSITY_CSV_EXAMPLE_URL,
-]
+
 DOWNLOAD_PATH_FOR_ASSETS = join("tests", "assets")
-
-
-def unzip_file(zip_file_path, dest_dir):
-    with zipfile.ZipFile(zip_file_path, "r") as f:
-        f.extractall(dest_dir)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def download_assets():
-    makedirs(DOWNLOAD_PATH_FOR_ASSETS, exist_ok=True)
-    for i, http_address in enumerate(TEST_ASSETS_TO_DOWNLOAD, start=1):
-        filename = f"file_{i}"
-        filepath = join(DOWNLOAD_PATH_FOR_ASSETS, filename)
-        if ".parquet" in http_address:
-            filepath += ".parquet"
-        if ".csv" in http_address:
-            filepath += ".csv"
-        if ".zip" in http_address:
-            filepath += ".zip"
-        if exists(filepath):
-            logger.info(
-                "Skipping {} since it exists at {}".format(http_address, filepath)
-            )
-            continue
-        logger.info("Downloading: {}, to: {}".format(http_address, filepath))
-        urllib.request.urlretrieve(http_address, filepath)
-        if ".zip" in filepath:
-            logger.info(
-                "Unzipping: {}, to: {}".format(filepath, DOWNLOAD_PATH_FOR_ASSETS)
-            )
-            unzip_file(filepath, DOWNLOAD_PATH_FOR_ASSETS)
-    return True
 
 
 def test_empty_rtdataset():

--- a/tests/test_torch_dataset.py
+++ b/tests/test_torch_dataset.py
@@ -1,0 +1,49 @@
+import logging
+from os.path import join
+
+import torch
+from datasets import Dataset
+
+from dlomix.data import FragmentIonIntensityDataset
+
+logger = logging.getLogger(__name__)
+
+RT_HUB_DATASET_NAME = "Wilhelmlab/prospect-ptms-irt"
+
+RAW_GENERIC_NESTED_DATA = {
+    "seq": ["[UNIMOD:737]-DASAQTTSHELTIPN-[]", "[UNIMOD:737]-DLHTGRLC[UNIMOD:4]-[]"],
+    "nested_feature": [[[30, 64]], [[25, 35]]],
+    "label": [0.1, 0.2],
+}
+
+
+DOWNLOAD_PATH_FOR_ASSETS = join("tests", "assets")
+
+
+def test_dataset_torch():
+    hfdata = Dataset.from_dict(RAW_GENERIC_NESTED_DATA)
+
+    intensity_dataset = FragmentIonIntensityDataset(
+        data_format="hf",
+        data_source=hfdata,
+        sequence_column="seq",
+        label_column="label",
+        model_features=["nested_feature"],
+        dataset_type="pt",
+        batch_size=2,
+        max_seq_len=15,
+    )
+
+    assert intensity_dataset.hf_dataset is not None
+    assert intensity_dataset._empty_dataset_mode is False
+
+    batch = next(iter(intensity_dataset.tensor_train_data))
+
+    assert list(batch["nested_feature"].shape) == [1, 1, 2]
+    assert list(batch["seq"].shape) == [1, 15]
+    assert list(batch["label"].shape) == [
+        1,
+    ]
+
+    assert batch["seq"].dtype == torch.int64
+    assert batch["label"].dtype == torch.float32

--- a/tests/test_torch_dataset.py
+++ b/tests/test_torch_dataset.py
@@ -1,6 +1,7 @@
 import logging
 from os.path import join
 
+import pytest
 import torch
 from datasets import Dataset
 
@@ -8,20 +9,9 @@ from dlomix.data import FragmentIonIntensityDataset
 
 logger = logging.getLogger(__name__)
 
-RT_HUB_DATASET_NAME = "Wilhelmlab/prospect-ptms-irt"
-
-RAW_GENERIC_NESTED_DATA = {
-    "seq": ["[UNIMOD:737]-DASAQTTSHELTIPN-[]", "[UNIMOD:737]-DLHTGRLC[UNIMOD:4]-[]"],
-    "nested_feature": [[[30, 64]], [[25, 35]]],
-    "label": [0.1, 0.2],
-}
-
-
-DOWNLOAD_PATH_FOR_ASSETS = join("tests", "assets")
-
 
 def test_dataset_torch():
-    hfdata = Dataset.from_dict(RAW_GENERIC_NESTED_DATA)
+    hfdata = Dataset.from_dict(pytest.global_variables["RAW_GENERIC_NESTED_DATA"])
 
     intensity_dataset = FragmentIonIntensityDataset(
         data_format="hf",
@@ -34,10 +24,13 @@ def test_dataset_torch():
         max_seq_len=15,
     )
 
+    logger.info(intensity_dataset)
     assert intensity_dataset.hf_dataset is not None
     assert intensity_dataset._empty_dataset_mode is False
 
     batch = next(iter(intensity_dataset.tensor_train_data))
+
+    logger.info(batch)
 
     assert list(batch["nested_feature"].shape) == [1, 1, 2]
     assert list(batch["seq"].shape) == [1, 15]


### PR DESCRIPTION
## Changes:
- extension of PeptideDataset to include torch tensor dataset generation using `pt` as the `dataset_type`
- added tests
- combined session preparation code in `conftest.py`so that it is executed once for both `test_datasets.py` and `test_torch_datasets.py`. Currently, `test_datasets.py` focuses on the dataset creation itself, while `test_torch_datasets.py` focuses on having torch tensor out of the dataset, a tensorflow equivalent can be added later.
- added `run_script` for torch retention time that is to be extended once models are available
